### PR TITLE
Represent DBF feature rows as easy-to-access maps

### DIFF
--- a/lib/exshape/dbf.ex
+++ b/lib/exshape/dbf.ex
@@ -39,8 +39,12 @@ defmodule Exshape.Dbf do
   defp trim_leading(s), do: s
 
   defp munge_row(columns, row) do
-    Enum.zip(columns, row)
-    |> Enum.map(fn {c, datum} -> munge(c.field_type, datum) end)
+    columns
+    |> Enum.zip(row)
+    |> Enum.map(fn {c, datum} ->
+      {c.name, munge(c.field_type, datum)}
+    end)
+    |> Enum.into(%{})
   end
 
   defp munge(:character, datum), do: trim_trailing(datum)

--- a/test/dbf_test.exs
+++ b/test/dbf_test.exs
@@ -29,9 +29,9 @@ defmodule DbfTest do
     |> Enum.into([])
 
     assert records == [
-      ["some chars", true, 4, 8.8, ~D[1980-10-11]],
-      ["more chars", false, 1, 2.2, ~D[1980-12-11]],
-      ["more characters", false, 1, 2.2, ~D[1980-12-11]]
+      %{"A_CHAR" => "some chars", "A_BOOL" => true, "A_NUMBER" => 4, "A_FLOAT" => 8.8, "A_DATE" => ~D[1980-10-11]},
+      %{"A_CHAR" => "more chars", "A_BOOL" => false, "A_NUMBER" => 1, "A_FLOAT" => 2.2, "A_DATE" => ~D[1980-12-11]},
+      %{"A_CHAR" => "more characters", "A_BOOL" => false, "A_NUMBER" => 1, "A_FLOAT" => 2.2, "A_DATE" => ~D[1980-12-11]},
     ]
   end
 

--- a/test/exshape_test.exs
+++ b/test/exshape_test.exs
@@ -10,9 +10,9 @@ defmodule ExshapeTest do
 
     [
       {shp_header, dbf_header},
-      {p0, [nil]},
-      {p1, [nil]},
-      {p2, [nil]}
+      {p0, %{"point_ID" => nil}},
+      {p1, %{"point_ID" => nil}},
+      {p2, %{"point_ID" => nil}}
     ] = Enum.into(stream, [])
 
     assert shp_header.bbox == %Exshape.Shp.Bbox{


### PR DESCRIPTION
This is primarily to make my life easier, but I think most people would
find this helpful. This way, instead of having to record what index a
particular column is, you can access the data in a more obvious way.