### PR TITLE
Remove elixir_uuid dependency

### DIFF
--- a/lib/exshape.ex
+++ b/lib/exshape.ex
@@ -43,7 +43,7 @@ defmodule Exshape do
     Returns a list of all the layers, where each layer is a tuple of layer name,
     projection, and the stream of features
 
-    By default this unzips to `/tmp/exshape_some_uuid`. Make sure
+    By default this unzips to `/tmp/exshape_some_random_string`. Make sure
     to clean up when you're done consuming the stream. Pass the `:working_dir`
     option to change this destination.
 
@@ -64,7 +64,7 @@ defmodule Exshape do
   @spec from_zip(String.t) :: [layer]
   def from_zip(path, opts \\ []) do
 
-    cwd = Keyword.get(opts, :working_dir, '/tmp/exshape_#{UUID.uuid4}')
+    cwd = Keyword.get(opts, :working_dir, '/tmp/exshape_#{random_string()}')
     size = Keyword.get(opts, :read_size, 1024 * 1024)
 
     with {:ok, files} <- :zip.table(String.to_charlist(path)) do
@@ -137,6 +137,10 @@ defmodule Exshape do
       nil -> false
       ext -> String.downcase(ext) == wanted_ext
     end
+  end
+
+  def random_string do
+    32 |> :crypto.strong_rand_bytes() |> Base.url_encode64()
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Exshape.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger]]
+    [extra_applications: [:crypto, :logger]]
   end
 
   # Dependencies can be Hex packages:
@@ -47,7 +47,6 @@ defmodule Exshape.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:elixir_uuid, "~> 1.2"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:poison, "~> 3.1", only: :test}
     ]


### PR DESCRIPTION
Replaces `UUID.uuid64` with a random-enough string using built in functions. Makes this library dependency-free and fixes current compiler warnings coming from `elixir_uuid`. Resolves #22 